### PR TITLE
Fix link to Omniverse renderer settings web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ I focused on [Omniverse Create](https://www.nvidia.com/en-us/omniverse/apps/crea
 
 Load procedure: drag and drop McUsd.usda file into the viewport of Omniverse Create.
 
-There are [a few renderers in Omniverse](https://docs.omniverse.nvidia.com/prod_kit/prod_materials-and-rendering/render-settings_overview.html). All results are from Omniverse Create 2022.
+There are [a few renderers in Omniverse](https://docs.omniverse.nvidia.com/prod_materials-and-rendering/prod_materials-and-rendering/render-settings_overview.html). All results are from Omniverse Create 2022.
 
 By default, the "RTX - Interactive (Path Tracing)" is used. This renderer is progressive, shooting more and more frames of rays and blending these results in. Here is the render after 512 accumulated frames (which is overkill):
 


### PR DESCRIPTION
This just fixes the link.